### PR TITLE
:boom: feat(exceptions): Add ConcurrentGenerationError

### DIFF
--- a/src/novelai_python/_exceptions.py
+++ b/src/novelai_python/_exceptions.py
@@ -49,6 +49,15 @@ class APIError(NovelAiError):
         }
 
 
+class ConcurrentGenerationError(APIError):
+    """
+    ConcurrentGenerationError is raised when the API returns an error.
+    """
+
+    def __init__(self, message: str, request: dict, response: Union[dict, str], status_code: str) -> None:
+        super().__init__(message, request, response, status_code)
+
+
 class AuthError(APIError):
     """
     AuthError is raised when the API returns an error.

--- a/src/novelai_python/sdk/ai/generate_image.py
+++ b/src/novelai_python/sdk/ai/generate_image.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr, field_validator, model_
 from typing_extensions import override
 
 from ..schema import ApiBaseModel
-from ..._exceptions import APIError, AuthError
+from ..._exceptions import APIError, AuthError, ConcurrentGenerationError
 from ..._response import ImageGenerateResp
 from ...credential import CredentialBase
 from ...utils import try_jsonfy, NovelAiMetadata
@@ -450,6 +450,14 @@ class GenerateImageInfer(ApiBaseModel):
                 if status_code in [409]:
                     # conflict error
                     raise APIError(message, request=request_data, status_code=status_code, response=_msg)
+                if status_code in [429]:
+                    # concurrent error
+                    raise ConcurrentGenerationError(
+                        message=message,
+                        request=request_data,
+                        status_code=status_code,
+                        response=_msg
+                    )
                 raise APIError(message, request=request_data, status_code=status_code, response=_msg)
             zip_file = ZipFile(BytesIO(response.content))
             unzip_content = []


### PR DESCRIPTION
Added a new exception class `ConcurrentGenerationError` to handle errors related to concurrent generation in the API. This error is raised when the API returns a status code of 429.